### PR TITLE
Add I2C support for linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +105,14 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -124,6 +144,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mach"
@@ -198,6 +226,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -305,6 +338,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +366,7 @@ name = "ublox"
 version = "0.1.4"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "zerocopy 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -333,7 +375,9 @@ dependencies = [
 name = "ubsniff"
 version = "0.1.4"
 dependencies = [
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "i2c-linux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialport 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ublox 0.1.4",
@@ -394,6 +438,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,12 +480,15 @@ dependencies = [
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+"checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum i2c-linux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c0268a871aaa071221d6c2875ebedcf64710e59b0d87c68c8faf5e98b87dd2a4"
 "checksum i2c-linux-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72b70fd3d30157850c87f4c7c09c0857d9c2e8c996bcbe23ec1299126e0479ec"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)" = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum mach 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
@@ -442,6 +497,7 @@ dependencies = [
 "checksum proc-macro-error 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 "checksum proc-macro-error-attr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 "checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+"checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 "checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
@@ -453,6 +509,7 @@ dependencies = [
 "checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
@@ -465,6 +522,7 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum zerocopy 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
 "checksum zerocopy-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "i2c-linux"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "i2c-linux-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "resize-slice 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "i2c-linux-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +224,14 @@ version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "resize-slice"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "uninitialized 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serialport"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +294,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,12 +326,14 @@ version = "0.1.4"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zerocopy 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ubsniff"
 version = "0.1.4"
 dependencies = [
+ "i2c-linux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialport 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ublox 0.1.4",
@@ -311,6 +352,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uninitialized"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -352,6 +398,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "zerocopy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zerocopy-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum CoreFoundation-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
 "checksum IOKit-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
@@ -365,6 +430,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+"checksum i2c-linux 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c0268a871aaa071221d6c2875ebedcf64710e59b0d87c68c8faf5e98b87dd2a4"
+"checksum i2c-linux-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72b70fd3d30157850c87f4c7c09c0857d9c2e8c996bcbe23ec1299126e0479ec"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)" = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 "checksum mach 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
@@ -378,17 +445,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 "checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+"checksum resize-slice 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a3cb2f74a9891e76958b9e0ccd269a25b466c3ae3bb3efd71db157248308c4a"
 "checksum serialport 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8d3ecaf58010bedccae17be55d4ed6f2ecde5646fc48ce8c66ea2d35a1419c"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
 "checksum structopt-derive 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
 "checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+"checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum uninitialized 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "74c1aa4511c38276c548406f0b1f5f8b793f000cfb51e18f278a102abd057e81"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
@@ -396,3 +466,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum zerocopy 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
+"checksum zerocopy-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [ "ubsniff" ]
 default-members = [ "ubsniff" ]
 
 [dependencies]
+log = "0.4.8"
 nom = "4"
 zerocopy = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ default-members = [ "ubsniff" ]
 
 [dependencies]
 nom = "4"
+zerocopy = "0.3.0"
 
 [dependencies.byteorder]
 version = "1"

--- a/src/framing/frame.rs
+++ b/src/framing/frame.rs
@@ -1,4 +1,5 @@
 use crate::framing::{Checksum, FrameVec};
+use crate::messages::Message;
 
 /// The type returned by [`Deframer::push()`] upon successfully parsing
 /// a u-blox message.
@@ -51,4 +52,32 @@ impl Frame {
         }
         message
     }
+}
+
+/// Frame a u-blox message to a buffer.
+pub fn frame<M: Message>(msg: &M, buf: &mut [u8]) -> Result<usize, ()> {
+    const FRAME_OVERHEAD: usize = 8;
+    if buf.len() < (FRAME_OVERHEAD + M::LEN) {
+        return Err(());
+    }
+    let buf = &mut buf[..M::LEN + FRAME_OVERHEAD];
+    // Prelude
+    {
+        let [len_lsb, len_msb] = (M::LEN as u16).to_le_bytes();
+        buf[..6].clone_from_slice(&[0xB5, 0x62, M::CLASS, M::ID, len_lsb, len_msb]);
+    }
+    // Mesage body.
+    msg.to_bytes(buf[6..(M::LEN + 6)].as_mut())?;
+    // Append checksum.
+    {
+        let mut cksm = Checksum::default();
+        // The checksum is calculated from class to end of message, hence
+        // `skip(2)`
+        for b in buf.iter().skip(2) {
+            cksm.push(*b);
+        }
+        let (ck_a, ck_b) = cksm.take();
+        buf[M::LEN + 6..].clone_from_slice(&[ck_a, ck_b]);
+    }
+    Ok(M::LEN + FRAME_OVERHEAD)
 }

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -8,7 +8,7 @@ mod frame;
 pub use checksum::Checksum;
 pub use deframer::{deframe, Deframer};
 pub use error::FrameError;
-pub use frame::Frame;
+pub use frame::{frame, Frame};
 
 /// TODO: add `std` feature and use `heapless::Vec<u8,
 /// heapless::consts::U128>` when not `std` feature is not enabled.

--- a/src/messages/cfg/mod.rs
+++ b/src/messages/cfg/mod.rs
@@ -1,0 +1,38 @@
+//! Configuration Input Messages: i.e. Configure the receiver.
+//!
+//! Messages in the CFG class can be used to configure the receiver and
+//! poll current configuration values. Any messages in the CFG class sent
+//! to the receiver are either acknowledged (with message UBX-ACK-ACK) if
+//! processed successfully or rejected (with message UBX-ACK-NAK) if
+//! processing unsuccessfully.
+
+mod msg;
+use crate::framing::Frame;
+use crate::messages::Message;
+pub use msg::*;
+
+/// Configuration messages.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Cfg {
+    SetMsgRates(SetMsgRates),
+}
+
+impl Cfg {
+    /// CFG class.
+    pub const CLASS: u8 = 0x06;
+
+    /// Parses a configuration message from a [`Frame`].
+    pub fn from_frame(frame: &Frame) -> Result<Self, ()> {
+        if frame.class != Self::CLASS {
+            return Err(());
+        };
+
+        match (frame.class, frame.id, frame.message.len()) {
+            (SetMsgRates::CLASS, SetMsgRates::ID, SetMsgRates::LEN) => Ok(Cfg::SetMsgRates(
+                SetMsgRates::parse(frame.message.as_ref())?,
+            )),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/messages/cfg/msg.rs
+++ b/src/messages/cfg/msg.rs
@@ -1,0 +1,92 @@
+use crate::messages::{primitive::*, Message};
+use zerocopy::{AsBytes, ByteSlice, FromBytes, LayoutVerified, Unaligned};
+
+/// Get/set message rate configuration(s) to/from the receiver.
+///
+/// Send rate is relative to the event a message is registered on. For
+/// example, if the rate of a navigation message is set to 2, the
+/// message is sent every second navigation solution.
+#[repr(C)]
+#[derive(AsBytes, Clone, Debug, Eq, FromBytes, PartialEq, Unaligned)]
+pub struct SetMsgRates {
+    /// Message class of message to configure (not `Self`'s class).
+    pub class: U1,
+    /// Message identifier of message to configure (not `Self`'s identifier).
+    pub id: U1,
+    /// DDC (I²C) rate.
+    pub ddc: U1,
+    /// UART 1 rate.
+    pub uart1: U1,
+    /// USB rate.
+    pub usb: U1,
+    /// SPI rate.
+    pub spi: U1,
+    /// Reserved
+    pub reserved1: U1,
+    /// Reserved
+    pub reserved2: U1,
+}
+
+impl Message for SetMsgRates {
+    const CLASS: u8 = 0x06;
+    const ID: u8 = 0x01;
+    const LEN: usize = 8;
+
+    fn to_bytes(&self, buf: &mut [u8]) -> Result<(), ()> {
+        if buf.len() < Self::LEN {
+            return Err(());
+        };
+        buf[..Self::LEN].clone_from_slice(self.as_bytes());
+        unimplemented!("this message type doesn't work as expected")
+    }
+}
+
+impl SetMsgRates {
+    /// Parses `Self` from provided buffer.
+    pub fn parse<B>(bytes: B) -> Result<Self, ()>
+    where
+        B: ByteSlice,
+    {
+        Ok(LayoutVerified::<B, Self>::new(bytes).ok_or(())?.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_can_parse() {
+        let bytes = [0x00, 0x01, 0x20, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00];
+        assert_eq!(
+            SetMsgRates::parse(bytes[1..].as_ref()).unwrap(),
+            SetMsgRates {
+                class: 0x01,
+                id: 0x20,
+                ddc: 0x00,
+                uart1: 0x01,
+                usb: 0x01,
+                spi: 0x00,
+                reserved1: 0x00,
+                reserved2: 0x00,
+            }
+        )
+    }
+
+    #[test]
+    fn test_can_encode() {
+        let bytes = [0x01, 0x20, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00];
+        let msg = SetMsgRates {
+            class: 0x01,
+            id: 0x20,
+            ddc: 0x00,
+            uart1: 0x01,
+            usb: 0x01,
+            spi: 0x00,
+            reserved1: 0x00,
+            reserved2: 0x00,
+        };
+
+        assert_eq!(msg.as_bytes(), bytes.as_ref());
+    }
+}

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,12 +1,16 @@
 //! u-blox message types.
+pub mod cfg;
 pub mod nav;
 pub mod primitive;
 use crate::framing::Frame;
+use cfg::Cfg;
 use nav::Nav;
 
 /// Top-level enum for valid u-blox messages.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Msg {
+    /// Configuration message.
+    Cfg(Cfg),
     /// Navigation message.
     Nav(Nav),
 }
@@ -15,6 +19,7 @@ impl Msg {
     /// Parses a u-blox message from a [`Frame`].
     pub fn from_frame(frame: &Frame) -> Result<Self, ()> {
         match frame.class {
+            cfg::Cfg::CLASS => Ok(Msg::Cfg(Cfg::from_frame(frame)?)),
             nav::Nav::CLASS => Ok(Msg::Nav(Nav::from_frame(frame)?)),
             _ => Err(()),
         }
@@ -29,4 +34,9 @@ pub trait Message {
     const ID: u8;
     /// Message length.
     const LEN: usize;
+
+    /// Encode message bytes to a buffer.
+    fn to_bytes(&self, _buf: &mut [u8]) -> Result<(), ()> {
+        unimplemented!()
+    }
 }

--- a/ubsniff/Cargo.toml
+++ b/ubsniff/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2018"
 serialport = { version = "3", default-features = false }
 structopt = "0.3"
 ublox = { path = ".." }
+
+
+[target.'cfg(target_os = "linux")'.dependencies]
+i2c-linux = "0.1.2"

--- a/ubsniff/Cargo.toml
+++ b/ubsniff/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Jay Kickliter <jay@kickliter.com>"]
 edition = "2018"
 
 [dependencies]
+env_logger = "0.7.1"
+log = "*"
 serialport = { version = "3", default-features = false }
 structopt = "0.3"
 ublox = { path = ".." }


### PR DESCRIPTION
This work isn't done, but this branch is living longer than it should. Considering no one uses this library, I'm going to take a mulligan. 

Additionally, this PR adds `log` support and removes some YOLO logging in the `ubsniff` application.